### PR TITLE
missing coauthor taxonomy term fix

### DIFF
--- a/components/class-go-local-coauthors-plus-query.php
+++ b/components/class-go-local-coauthors-plus-query.php
@@ -46,7 +46,10 @@ class GO_Local_Coauthors_Plus_Query
 			}
 			else
 			{
-				// this is already a user_nicename
+				// this is already a user_nicename so we start with it
+				$author_term = $author_name;
+
+				// but try to use the coauthor term if possible.
 				$author_name = $wp_query->query_vars['author_name'];
 				$coauthor = $coauthors_plus->get_coauthor_by( 'user_nicename', $author_name );
 				if ( FALSE != $coauthor )


### PR DESCRIPTION
handle the case where co-authors-plus has not created an author taxonomy term for for an author yet. in that case just use the author's user_nicename. without we can get empty author query results for some authors when we shouldn't.

part of the fix for github #691 (https://github.com/GigaOM/legacy-pro/issues/691)
