### PR TITLE
fixes missing author search result when author is not a taxonomy term

### DIFF
--- a/components/class-go-local-coauthors-plus-query.php
+++ b/components/class-go-local-coauthors-plus-query.php
@@ -49,7 +49,7 @@ class GO_Local_Coauthors_Plus_Query
 				// this is already a user_nicename (slug) so we start with it
 				$author_term = $wp_query->query_vars['author_name'];
 
-				$coauthor = $coauthors_plus->get_coauthor_by( 'user_nicename', $wp_query->query_vars['author_name'] );
+				$coauthor = $coauthors_plus->get_coauthor_by( 'user_nicename', $author_term );
 				if ( FALSE != $coauthor )
 				{
 					$term_obj = $coauthors_plus->get_author_term( $coauthor );


### PR DESCRIPTION
give up on converting an author or author_name query into a tax query if the author is not a taxonomy term. this fixes the bug where search for those authors return empty result when there should be some search hits.

instead of converting an author query where the author is not an author taxonomy term, we abort converting the author query into a tax query and let it run as an author query.
