### PR TITLE
Small tweak to parse_query so that is_tax is properly set to TRUE after ...

### DIFF
--- a/components/class-go-local-coauthors-plus-query.php
+++ b/components/class-go-local-coauthors-plus-query.php
@@ -97,6 +97,7 @@ class GO_Local_Coauthors_Plus_Query
 			$wp_query->set( 'author_name', '' );
 			$wp_query->set( 'author', '' );
 			$wp_query->is_author = FALSE;
+			$wp_query->is_tax = TRUE;
 		}//END if
 	}//END parse_query
 


### PR DESCRIPTION
...converting author queries to coauthor plus ones.

Part 1 of a fix for:

https://github.com/GigaOM/legacy-pro/issues/933
