### PR TITLE
detect invalid author name and author id

### DIFF
--- a/components/class-go-local-coauthors-plus-query.php
+++ b/components/class-go-local-coauthors-plus-query.php
@@ -48,6 +48,12 @@ class GO_Local_Coauthors_Plus_Query
 				{
 					$user_nicename = $user->user_nicename;
 				}
+				else
+				{
+					// we got an invalid author id
+					$wp_query->set_404();
+					return;
+				}
 			}
 			else
 			{
@@ -74,6 +80,7 @@ class GO_Local_Coauthors_Plus_Query
 			// give up if we don't find the author as an author term
 			if ( FALSE == $author_term )
 			{
+				$wp_query->set_404();
 				return;
 			}
 


### PR DESCRIPTION
make sure we don't get any query results when an invalid author id or author name is passed in.

see https://github.com/GigaOM/legacy-pro/issues/2043
