### PR TITLE
Add in oxford commas for researc/search in a more accurate

### DIFF
--- a/components/class-go-local-coauthors-plus.php
+++ b/components/class-go-local-coauthors-plus.php
@@ -69,7 +69,7 @@ class GO_Local_Coauthors_Plus
 			$after = '';
 		}//end if
 
-		$author = apply_filters( 'go_coauthors_posts_links', coauthors_posts_links( $between, NULL, $before, $after, false ), $post_id );
+		$author = apply_filters( 'go_coauthors_posts_links', coauthors_posts_links( $between, $betweenLast, $before, $after, false ), $post_id );
 
 		// if there are double percents, we're on research/search where oxford commas should be used
 		if ( substr_count( $author, '%%' ) )


### PR DESCRIPTION
See: https://github.com/GigaOM/legacy-pro/issues/2491

Here's the result:
![screen shot 2014-02-24 at 10 34 44 am](https://f.cloud.github.com/assets/430385/2246899/361b85ec-9d69-11e3-8678-36858d0fb3cc.png)
![screen shot 2014-02-24 at 10 33 47 am](https://f.cloud.github.com/assets/430385/2246886/1b186012-9d69-11e3-97f1-562e33800bac.png)
![screen shot 2014-02-24 at 10 33 09 am](https://f.cloud.github.com/assets/430385/2246887/1b18a068-9d69-11e3-9e65-61fa41591241.png)
