### PR TITLE
hook to the 'posts_selection' action to restore the $wp_query->is_author flag

### DIFF
--- a/components/class-go-local-coauthors-plus-query.php
+++ b/components/class-go-local-coauthors-plus-query.php
@@ -123,7 +123,7 @@ class GO_Local_Coauthors_Plus_Query
 		$wp_query->is_author = FALSE;
 		$wp_query->is_tax = TRUE;
 
-		// set this flag so we know we've modified the authorh query
+		// set this flag so we know we've modified the author query
  		$this->converted_author_query = TRUE;
 
 		// We just converted an author query to a coauthors-plus taxonomy


### PR DESCRIPTION
set it back to `TRUE` if we have a coauthors-plus taxonomy query on our hands

see https://github.com/GigaOM/gigaom/issues/4904
