### PR TITLE
Add a twitter icon to author links ONLY when theme_preview is active

### DIFF
--- a/components/class-go-local-coauthors-plus.php
+++ b/components/class-go-local-coauthors-plus.php
@@ -148,7 +148,7 @@ class GO_Local_Coauthors_Plus
 		}//end if
 
 		$link = sprintf(
-				'<span class="vcard"><a itemprop="author" href="%1$s" title="%2$s" rel="%3$s">%4$s</a></span>%5$s',
+				'<span class="author-container"><span class="vcard"><a itemprop="author" href="%1$s" title="%2$s" rel="%3$s">%4$s</a></span>%5$s</span>',
 				esc_url( $args['href'] ),
 				esc_attr( $args['title'] ),
 				esc_attr( $args['rel'] ),


### PR DESCRIPTION
This changeset continues existing functionality for the current themes:

![screen shot 2014-09-30 at 2 51 15 pm](https://cloud.githubusercontent.com/assets/430385/4464328/d182e1f0-48d2-11e4-85ed-33b321f96929.png)

But adds the new elements when the appropriate plugins and functions exist:

![screen shot 2014-09-30 at 2 54 40 pm](https://cloud.githubusercontent.com/assets/430385/4464383/400a1bf2-48d3-11e4-9e43-8d1b3fb5fcdf.png)

See: https://github.com/GigaOM/gigaom/issues/5440
